### PR TITLE
fix/dapr starter

### DIFF
--- a/src/Caller/Masa.Utils.Caller.Core/CallerBase.cs
+++ b/src/Caller/Masa.Utils.Caller.Core/CallerBase.cs
@@ -2,7 +2,7 @@
 
 public abstract class CallerBase
 {
-    public string Name { get; set; } = default!;
+    public abstract string Name { get; set; }
 
     protected CallerOptions CallerOptions { get; private set; } = default!;
 

--- a/src/Caller/Masa.Utils.Caller.Core/CallerOptions.cs
+++ b/src/Caller/Masa.Utils.Caller.Core/CallerOptions.cs
@@ -2,16 +2,31 @@ namespace Masa.Utils.Caller.Core;
 
 public class CallerOptions
 {
-    internal List<CallerRelations> Callers = new();
+    internal readonly List<CallerRelations> Callers = new();
 
     public IServiceCollection Services { get; }
 
+    private Assembly[] _assemblies = AppDomain.CurrentDomain.GetAssemblies();
+
+    public Assembly[] Assemblies
+    {
+        get => _assemblies;
+        set
+        {
+            ArgumentNullException.ThrowIfNull(value, nameof(Assemblies));
+
+            _assemblies = value;
+        }
+    }
+
+    public ServiceLifetime CallerLifetime { get; set; }
+
     public JsonSerializerOptions? JsonSerializerOptions { get; set; }
 
-    public CallerOptions(IServiceCollection services, JsonSerializerOptions? jsonSerializerOptions = null)
+    public CallerOptions(IServiceCollection services)
     {
         Services = services;
-        JsonSerializerOptions = jsonSerializerOptions;
+        CallerLifetime = ServiceLifetime.Scoped;
     }
 
     public void AddCaller(string name, bool isDefault, Func<IServiceProvider, ICallerProvider> func)

--- a/src/Caller/Masa.Utils.Caller.Core/_Imports.cs
+++ b/src/Caller/Masa.Utils.Caller.Core/_Imports.cs
@@ -1,10 +1,9 @@
 global using Google.Protobuf;
 global using Masa.Utils.Caller.Core.Internal;
+global using Masa.Utils.Exceptions;
 global using Microsoft.Extensions.DependencyInjection;
 global using Microsoft.Extensions.DependencyInjection.Extensions;
-global using System.Reflection;
-global using System.Text.Json;
 global using System.Net;
 global using System.Net.Http.Json;
-global using Masa.Utils.Exceptions;
-
+global using System.Reflection;
+global using System.Text.Json;

--- a/src/Development/Masa.Utils.Development.Dapr.AspNetCore/README.md
+++ b/src/Development/Masa.Utils.Development.Dapr.AspNetCore/README.md
@@ -26,7 +26,7 @@ builder.Services.AddDaprStarter();
 ``` C#
 builder.Services.AddDaprStarter(opt =>
 {
-    opt.AppId = "masa.dapr.test";
+    opt.AppId = "masa-dapr-test";
     opt.AppPort = 5001;
     opt.AppIdSuffix = "";
     opt.DaprHttpPort = 8080;

--- a/src/Development/Masa.Utils.Development.Dapr.AspNetCore/README.md
+++ b/src/Development/Masa.Utils.Development.Dapr.AspNetCore/README.md
@@ -36,7 +36,7 @@ builder.Services.AddDaprStarter(opt =>
 
 2. The configuration file specifies the configuration
 
-first step:
+First step:
 
 ``` appsettings.json
 {

--- a/src/Development/Masa.Utils.Development.Dapr.AspNetCore/README.md
+++ b/src/Development/Masa.Utils.Development.Dapr.AspNetCore/README.md
@@ -57,15 +57,3 @@ builder.Services.AddDaprStarter(builder.Configuration.GetSection("DaprOptions");
 ```
 
 Advantages: After the configuration is changed, the dapr process is restarted and updated, and the project does not need to be restarted
-
-### rule
-
-dapr AppId naming rules default:
-
-AppId + "-" + AppIdSuffix
-
-AppId default: Appid.Replace(".","-")
-
-AppIdSuffix default: network card address
-
-When AppIdSuffix is empty, the appid of dapr is equal to AppId

--- a/src/Development/Masa.Utils.Development.Dapr.AspNetCore/README.md
+++ b/src/Development/Masa.Utils.Development.Dapr.AspNetCore/README.md
@@ -41,7 +41,7 @@ first step:
 ``` appsettings.json
 {
   "DaprOptions": {
-    "AppId": "masa.dapr.test",
+    "AppId": "masa-dapr-test",
     "AppPort": 5001,
     "AppIdSuffix": "",
     "DaprHttpPort": 8080,

--- a/src/Development/Masa.Utils.Development.Dapr.AspNetCore/README.md
+++ b/src/Development/Masa.Utils.Development.Dapr.AspNetCore/README.md
@@ -1,0 +1,71 @@
+[中](README.zh-CN.md) | EN
+
+## Masa.Utils.Development.Dapr.AspNetCore
+
+Responsibilities:
+
+Assist in managing the dapr process to reduce the dependency on docker compose during development
+
+### Basic usage:
+
+1. Install Masa.Utils.Development.Dapr.AspNetCore
+``` C#
+Install-Package Masa.Utils.Development.Dapr.AspNetCore
+```
+
+2. Add DaprStarter to assist in managing the dapr process (recommended to be used in the development environment)
+
+``` C#
+builder.Services.AddDaprStarter();
+```
+
+### Advanced usage:
+
+1. Specify the configuration in the code
+
+``` C#
+builder.Services.AddDaprStarter(opt =>
+{
+    opt.AppId = "masa.dapr.test";
+    opt.AppPort = 5001;
+    opt.AppIdSuffix = "";
+    opt.DaprHttpPort = 8080;
+    opt.DaprGrpcPort = 8081;
+});
+```
+
+2. The configuration file specifies the configuration
+
+first step:
+
+``` appsettings.json
+{
+  "DaprOptions": {
+    "AppId": "masa.dapr.test",
+    "AppPort": 5001,
+    "AppIdSuffix": "",
+    "DaprHttpPort": 8080,
+    "DaprGrpcPort": 8081
+  }
+}
+```
+
+Step 2:
+
+``` C#
+builder.Services.AddDaprStarter(builder.Configuration.GetSection("DaprOptions");
+```
+
+Advantages: After the configuration is changed, the dapr process is restarted and updated, and the project does not need to be restarted
+
+### rule
+
+dapr AppId naming rules default:
+
+AppId + "-" + AppIdSuffix
+
+AppId default: Appid.Replace(".","-")
+
+AppIdSuffix default: network card address
+
+When AppIdSuffix is empty, the appid of dapr is equal to AppId

--- a/src/Development/Masa.Utils.Development.Dapr.AspNetCore/README.zh-CN.md
+++ b/src/Development/Masa.Utils.Development.Dapr.AspNetCore/README.zh-CN.md
@@ -57,15 +57,3 @@ builder.Services.AddDaprStarter(builder.Configuration.GetSection("DaprOptions"))
 ```
 
 优势：支持配置变更后，dapr 进程重启更新，项目无需重新启动
-
-### 规则
-
-dapr AppId命名规则默认：
-
-AppId + "-" +  AppIdSuffix
-
-AppId默认：Appid.Replace(".","-")
-
-AppIdSuffix默认：网卡地址
-
-当AppIdSuffix为空时，dapr的appid等于AppId

--- a/src/Development/Masa.Utils.Development.Dapr.AspNetCore/README.zh-CN.md
+++ b/src/Development/Masa.Utils.Development.Dapr.AspNetCore/README.zh-CN.md
@@ -26,7 +26,7 @@ builder.Services.AddDaprStarter();
 ```C#
 builder.Services.AddDaprStarter(opt =>
 {
-    opt.AppId = "masa.dapr.test";
+    opt.AppId = "masa-dapr-test";
     opt.AppPort = 5001;
     opt.AppIdSuffix = "";
     opt.DaprHttpPort = 8080;
@@ -41,7 +41,7 @@ builder.Services.AddDaprStarter(opt =>
 ``` appsettings.json
 {
   "DaprOptions": {
-    "AppId": "masa.dapr.test",
+    "AppId": "masa-dapr-test",
     "AppPort": 5001,
     "AppIdSuffix": "",
     "DaprHttpPort": 8080,

--- a/src/Development/Masa.Utils.Development.Dapr.AspNetCore/README.zh-CN.md
+++ b/src/Development/Masa.Utils.Development.Dapr.AspNetCore/README.zh-CN.md
@@ -1,0 +1,71 @@
+中 | [EN](README.md)
+
+## Masa.Utils.Development.Dapr.AspNetCore
+
+职责：
+
+协助管理dapr进程，用于开发时减少对docker compose的依赖
+
+### 基本用法：
+
+1. 安装Masa.Utils.Development.Dapr.AspNetCore
+```C#
+Install-Package Masa.Utils.Development.Dapr.AspNetCore
+```
+
+2. 添加DaprStarter协助管理dapr进程（建议在开发环境使用）
+
+```C#
+builder.Services.AddDaprStarter();
+```
+
+### 高级用法：
+
+1. 代码中指定配置
+
+```C#
+builder.Services.AddDaprStarter(opt =>
+{
+    opt.AppId = "masa.dapr.test";
+    opt.AppPort = 5001;
+    opt.AppIdSuffix = "";
+    opt.DaprHttpPort = 8080;
+    opt.DaprGrpcPort = 8081;
+});
+```
+
+2. 配置文件指定配置
+
+第一步：
+
+``` appsettings.json
+{
+  "DaprOptions": {
+    "AppId": "masa.dapr.test",
+    "AppPort": 5001,
+    "AppIdSuffix": "",
+    "DaprHttpPort": 8080,
+    "DaprGrpcPort": 8081
+  }
+}
+```
+
+第二步：
+
+``` C#
+builder.Services.AddDaprStarter(builder.Configuration.GetSection("DaprOptions"));
+```
+
+优势：支持配置变更后，dapr 进程重启更新，项目无需重新启动
+
+### 规则
+
+dapr AppId命名规则默认：
+
+AppId + "-" +  AppIdSuffix
+
+AppId默认：Appid.Replace(".","-")
+
+AppIdSuffix默认：网卡地址
+
+当AppIdSuffix为空时，dapr的appid等于AppId

--- a/src/Development/Masa.Utils.Development.Dapr.AspNetCore/ServiceCollectionExtensions.cs
+++ b/src/Development/Masa.Utils.Development.Dapr.AspNetCore/ServiceCollectionExtensions.cs
@@ -1,42 +1,38 @@
-﻿namespace Masa.Utils.Development.Dapr.AspNetCore;
+namespace Masa.Utils.Development.Dapr.AspNetCore;
 
 public static class ServiceCollectionExtensions
 {
     public static IServiceCollection AddDaprStarter(
         this IServiceCollection services,
-        Action<DaprOptions>? action = null,
-        Action<DaprBackgroundOptions>? daprBackgroundOptionsAction = null)
+        Action<DaprOptions>? daprOptionAction = null)
     {
-        DaprOptions daprOptions = new();
-        action?.Invoke(daprOptions);
-        return services.AddDaprStarter(() => daprOptions, daprBackgroundOptionsAction);
+        return services.AddDaprStarter(opt =>
+        {
+            daprOptionAction?.Invoke(opt);
+        }, _ => { });
     }
 
     public static IServiceCollection AddDaprStarter(this IServiceCollection services,
-        Func<DaprOptions> func,
-        Action<DaprBackgroundOptions>? action = null)
+    Action<DaprOptions> daprOptionAction,
+    Action<DaprBackgroundOptions> action)
     {
         if (services.Any(service => service.ImplementationType == typeof(DaprService)))
-        {
             return services;
-        }
         services.AddSingleton<DaprService>();
 
-        if (action != null)
-            services.Configure(action);
+        services.Configure(action);
 
         services.AddHostedService<DaprBackgroundService>();
         services.Configure<HostOptions>(opts => opts.ShutdownTimeout = TimeSpan.FromSeconds(15));
-        return services.AddDaprStarterCore(func);
+        return services.AddDaprStarterCore(daprOptionAction);
     }
 
     public static IServiceCollection AddDaprStarter(this IServiceCollection services, IConfiguration configuration)
     {
         if (services.Any(service => service.ImplementationType == typeof(DaprService)))
-        {
             return services;
-        }
         services.AddSingleton<DaprService>();
+
         services.AddHostedService<DaprBackgroundService>();
         services.Configure<DaprBackgroundOptions>(configuration);
         return services.AddDaprStarterCore(configuration);

--- a/src/Development/Masa.Utils.Development.Dapr/DaprOptions.cs
+++ b/src/Development/Masa.Utils.Development.Dapr/DaprOptions.cs
@@ -43,21 +43,61 @@ public class DaprOptions
         }
     }
 
+    private string _appIdSuffix = DefaultOptions.DefaultAppidSuffix;
+
     /// <summary>
     /// Appid suffix
     /// optional. the default is the current MAC address
     /// </summary>
-    public string AppIdSuffix { get; set; } = DefaultOptions.DefaultAppidSuffix;
+    public string AppIdSuffix
+    {
+        get => _appIdSuffix;
+        set
+        {
+            if (value == ".")
+            {
+                throw new NotSupportedException("AppIdSuffix is not supported as .");
+            }
+
+            _appIdSuffix = value;
+        }
+    }
+
+    private int? _maxConcurrency;
 
     /// <summary>
     /// The concurrency level of the application, otherwise is unlimited
     /// </summary>
-    public string? MaxConcurrency { get; set; }
+    public int? MaxConcurrency
+    {
+        get => _maxConcurrency;
+        set
+        {
+            if (value is <= 0)
+            {
+                throw new NotSupportedException($"{nameof(MaxConcurrency)} must be greater than 0 .");
+            }
+
+            _maxConcurrency = value;
+        }
+    }
+
+    private ushort? _appPort;
 
     /// <summary>
     /// The port your application is listening on
     /// </summary>
-    public ushort? AppPort { get; set; }
+    public ushort? AppPort
+    {
+        get => _appPort;
+        set
+        {
+            if (value is <= 0)
+                throw new NotSupportedException($"{nameof(AppPort)} must be greater than 0 .");
+
+            _appPort = value;
+        }
+    }
 
     /// <summary>
     /// The protocol (gRPC or HTTP) Dapr uses to talk to the application. Valid values are: http or grpc
@@ -85,15 +125,39 @@ public class DaprOptions
     /// </summary>
     public string? ComponentPath { get; set; }
 
+    private ushort? _daprGrpcPort;
+
     /// <summary>
     /// The gRPC port for Dapr to listen on
     /// </summary>
-    public ushort? DaprGrpcPort { get; set; }
+    public ushort? DaprGrpcPort
+    {
+        get => _daprGrpcPort;
+        set
+        {
+            if (value is <= 0)
+                throw new NotSupportedException($"{nameof(DaprGrpcPort)} must be greater than 0 .");
+
+            _daprGrpcPort = value;
+        }
+    }
+
+    private ushort? _daprHttpPort;
 
     /// <summary>
     /// The HTTP port for Dapr to listen on
     /// </summary>
-    public ushort? DaprHttpPort { get; set; }
+    public ushort? DaprHttpPort
+    {
+        get => _daprHttpPort;
+        set
+        {
+            if (value is <= 0)
+                throw new NotSupportedException($"{nameof(DaprHttpPort)} must be greater than 0 .");
+
+            _daprHttpPort = value;
+        }
+    }
 
     /// <summary>
     /// Enable pprof profiling via an HTTP endpoint
@@ -117,14 +181,43 @@ public class DaprOptions
     public string? PlacementHostAddress { get; set; }
 
     /// <summary>
+    /// Address for the Sentry CA service
+    /// </summary>
+    public string? SentryAddress { get; set; }
+
+    private ushort? _metricsPort;
+
+    /// <summary>
     /// The port that Dapr sends its metrics information to
     /// </summary>
-    public string? MetricsPort { get; set; }
+    public ushort? MetricsPort
+    {
+        get => _metricsPort;
+        set
+        {
+            if (value is <= 0)
+                throw new NotSupportedException($"{nameof(MetricsPort)} must be greater than 0 .");
+
+            _metricsPort = value;
+        }
+    }
+
+    private ushort? _profilePort;
 
     /// <summary>
     /// The port for the profile server to listen on
     /// </summary>
-    public int? ProfilePort { get; set; }
+    public ushort? ProfilePort
+    {
+        get => _profilePort;
+        set
+        {
+            if (value is <= 0)
+                throw new NotSupportedException($"{nameof(ProfilePort)} must be greater than 0 .");
+
+            _profilePort = value;
+        }
+    }
 
     /// <summary>
     /// Path to a unix domain socket dir mount. If specified
@@ -133,16 +226,46 @@ public class DaprOptions
     /// </summary>
     public string? UnixDomainSocket { get; set; }
 
+    private int? _daprMaxRequestSize;
+
     /// <summary>
     /// Max size of request body in MB.
     /// </summary>
-    public int? DaprMaxRequestSize { get; set; }
+    public int? DaprMaxRequestSize
+    {
+        get => _daprMaxRequestSize;
+        set
+        {
+            if (value is <= 0)
+                throw new NotSupportedException($"{nameof(DaprMaxRequestSize)} must be greater than 0 .");
+
+            _daprMaxRequestSize = value;
+        }
+    }
+
+    private int _heartBeatInterval = Const.DEFAULT_HEARTBEATINTERVAL;
 
     /// <summary>
     /// Heartbeat detection interval, used to detect dapr status
     /// default: 5000 ms
     /// </summary>
-    public int? HeartBeatInterval { get; set; }
+    public int? HeartBeatInterval
+    {
+        get => _heartBeatInterval;
+        set
+        {
+            if (value < 0)
+                throw new NotSupportedException($"{nameof(DaprMaxRequestSize)} must be greater than or equal to 0 .");
+
+            _heartBeatInterval = value ?? Const.DEFAULT_HEARTBEATINTERVAL;
+        }
+    }
+
+    /// <summary>
+    /// Start the heartbeat check to ensure that the dapr program is active.
+    /// When the heartbeat check is turned off, dapr will not start automatically after it exits abnormally.
+    /// </summary>
+    public bool EnableHeartBeat { get; set; } = true;
 
     public bool CreateNoWindow { get; set; } = true;
 }

--- a/src/Development/Masa.Utils.Development.Dapr/IDaprProcess.cs
+++ b/src/Development/Masa.Utils.Development.Dapr/IDaprProcess.cs
@@ -1,6 +1,6 @@
-﻿namespace Masa.Utils.Development.Dapr;
+namespace Masa.Utils.Development.Dapr;
 
-public interface IDaprProcess
+public interface IDaprProcess : IDisposable
 {
     void Start(DaprOptions options, CancellationToken cancellationToken = default);
 

--- a/src/Development/Masa.Utils.Development.Dapr/Internal/DaprCoreOptions.cs
+++ b/src/Development/Masa.Utils.Development.Dapr/Internal/DaprCoreOptions.cs
@@ -33,6 +33,8 @@ internal class DaprCoreOptions
     /// </summary>
     public ushort? DaprHttpPort { get; private set; }
 
+    public bool EnableHeartBeat { get; private set; }
+
     public int HeartBeatInterval { get; }
 
     public bool CreateNoWindow { get; } = true;
@@ -40,7 +42,7 @@ internal class DaprCoreOptions
     /// <summary>
     /// The concurrency level of the application, otherwise is unlimited
     /// </summary>
-    public string? MaxConcurrency { get; set; }
+    public int? MaxConcurrency { get; set; }
 
     /// <summary>
     /// Dapr configuration file
@@ -80,14 +82,19 @@ internal class DaprCoreOptions
     public string? PlacementHostAddress { get; set; }
 
     /// <summary>
+    /// Address for the Sentry CA service
+    /// </summary>
+    public string? SentryAddress { get; set; }
+
+    /// <summary>
     /// The port that Dapr sends its metrics information to
     /// </summary>
-    public string? MetricsPort { get; set; }
+    public ushort? MetricsPort { get; set; }
 
     /// <summary>
     /// The port for the profile server to listen on
     /// </summary>
-    public int? ProfilePort { get; set; }
+    public ushort? ProfilePort { get; set; }
 
     /// <summary>
     /// Path to a unix domain socket dir mount. If specified
@@ -108,6 +115,7 @@ internal class DaprCoreOptions
         bool? enableSsl,
         ushort? daprGrpcPort,
         ushort? daprHttpPort,
+        bool enableHeartBeat,
         int heartBeatInterval,
         bool createNoWindow)
     {
@@ -117,6 +125,7 @@ internal class DaprCoreOptions
         EnableSsl = enableSsl;
         DaprGrpcPort = daprGrpcPort;
         DaprHttpPort = daprHttpPort;
+        EnableHeartBeat = enableHeartBeat;
         HeartBeatInterval = heartBeatInterval;
         CreateNoWindow = createNoWindow;
     }

--- a/src/Development/Masa.Utils.Development.Dapr/Internal/ProcessUtils.cs
+++ b/src/Development/Masa.Utils.Development.Dapr/Internal/ProcessUtils.cs
@@ -15,6 +15,7 @@ internal class ProcessUtils
         bool createNoWindow = true,
         bool isWait = false)
     {
+        _logger?.LogDebug("FileName: {FileName}, Arguments: {Arguments}", fileName, arguments);
         var processStartInfo = new ProcessStartInfo
         {
             FileName = fileName,
@@ -57,9 +58,29 @@ internal class ProcessUtils
 
     public event EventHandler Exit = default!;
 
-    protected virtual void OnOutputDataReceived(DataReceivedEventArgs args) => OutputDataReceived(this, args);
+    protected virtual void OnOutputDataReceived(DataReceivedEventArgs args)
+    {
+        try
+        {
+            OutputDataReceived(this, args);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError("ProcessUtils: error in output information ", ex);
+        }
+    }
 
-    protected virtual void OnErrorDataReceived(DataReceivedEventArgs args) => ErrorDataReceived?.Invoke(this, args);
+    protected virtual void OnErrorDataReceived(DataReceivedEventArgs args)
+    {
+        try
+        {
+            ErrorDataReceived?.Invoke(this, args);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError("execution error", ex);
+        }
+    }
 
     protected virtual void OnExited() => Exit(this, EventArgs.Empty);
 }

--- a/src/Development/Masa.Utils.Development.Dapr/README.md
+++ b/src/Development/Masa.Utils.Development.Dapr/README.md
@@ -23,7 +23,7 @@ Install-Package Masa.Utils.Development.Dapr.AspNetCore
 builder.Services.AddDaprStarterCore();
 ```
 
-3. Inject IDaprProcess at the specified location as needed, and then call the Start method to start the dapr process or hand it over to Masa.Utils.Development.Dapr.AspNetCore to manage the dapr process. Related documents can be found at [View](../Masa.Utils.Development .Dapr.AspNetCore/README.zh-CN.md)
+3. Inject IDaprProcess at the specified location as needed, and then call the Start method to start the dapr process or hand it over to Masa.Utils.Development.Dapr.AspNetCore to manage the dapr process. Related documents can be found at [View](../Masa.Utils.Development.Dapr.AspNetCore/README.md)
 
 Example：
 

--- a/src/Development/Masa.Utils.Development.Dapr/README.md
+++ b/src/Development/Masa.Utils.Development.Dapr/README.md
@@ -77,3 +77,19 @@ Example: ubuntu:
 ````
 apt-get install net-tools
 ````
+
+2. AppId, AppIdSuffix strongly recommend not to enter a string containing ., otherwise it will cause problems with the dapr call. It is recommended to use -
+    1. Dapr AppID follows the FQDN format, which includes the target namespace
+    2. FQDN is spliced with the symbol .
+
+### rule
+
+dapr AppId naming rules default:
+
+AppId + "-" + AppIdSuffix
+
+AppId default: Appid.Replace(".","-")
+
+AppIdSuffix default: network card address
+
+When AppIdSuffix is empty, the appid of dapr is equal to AppId

--- a/src/Development/Masa.Utils.Development.Dapr/README.md
+++ b/src/Development/Masa.Utils.Development.Dapr/README.md
@@ -82,7 +82,7 @@ apt-get install net-tools
     1. Dapr AppID follows the FQDN format, which includes the target namespace
     2. FQDN is spliced with the symbol .
 
-### rule
+### Rule
 
 dapr AppId naming rules default:
 

--- a/src/Development/Masa.Utils.Development.Dapr/README.md
+++ b/src/Development/Masa.Utils.Development.Dapr/README.md
@@ -1,0 +1,79 @@
+[中](README.zh-CN.md) | EN
+
+## Masa.Utils.Development.Dapr
+
+Dapr Starter Core Library
+
+Responsibilities:
+
+Provide core support for Masa.Utils.Development.Dapr.AspNetCore
+
+The start, stop, refresh, and dapr daemon of the dapr process are provided by such libraries
+
+### Usage:
+
+1. Install Masa.Utils.Development.Dapr.AspNetCore
+``` C#
+Install-Package Masa.Utils.Development.Dapr.AspNetCore
+```
+
+2. Add DaprStarter to assist in managing the dapr process (recommended to be used in the development environment)
+
+``` C#
+builder.Services.AddDaprStarterCore();
+```
+
+3. Inject IDaprProcess at the specified location as needed, and then call the Start method to start the dapr process or hand it over to Masa.Utils.Development.Dapr.AspNetCore to manage the dapr process. Related documents can be found at [View](../Masa.Utils.Development .Dapr.AspNetCore/README.zh-CN.md)
+
+Example：
+
+New DaprController
+
+``` C# DaprController.cs
+public class DaprController : ControllerBase
+{
+    private readonly IDaprProcess _daprProcess;
+
+    private readonly DaprOptions _options;
+
+    public DaprController(IDaprProcess daprProcess, IOptions<DaprOptions> options)
+    {
+        _daprProcess = daprProcess;
+        _options = options.Value;
+    }
+
+    [HttpGet(Name = "Start")]
+    public string Start()
+    {
+        _daprProcess.Start(_options);
+        return "start success";
+    }
+
+    [HttpGet(Name = "Stop")]
+    public string Stop()
+    {
+        _daprProcess.Stop();
+        return "stop success";
+    }
+}
+```
+
+## Notice
+
+The netstat command is used in the library, please make sure the netstat command is available
+
+> Windows system supports netstat command by default without special installation
+>
+> Linux and OSX need to confirm by themselves whether netstat is installed on the computer
+
+Open a terminal and enter the following command to confirm that the computer supports the netstat command:
+
+````
+netstat -h
+````
+
+Example: ubuntu:
+
+````
+apt-get install net-tools
+````

--- a/src/Development/Masa.Utils.Development.Dapr/README.md
+++ b/src/Development/Masa.Utils.Development.Dapr/README.md
@@ -60,7 +60,7 @@ public class DaprController : ControllerBase
 
 ## Notice
 
-The netstat command is used in the library, please make sure the netstat command is available
+1. The netstat command is used in the library, please make sure the netstat command is available
 
 > Windows system supports netstat command by default without special installation
 >

--- a/src/Development/Masa.Utils.Development.Dapr/README.zh-CN.md
+++ b/src/Development/Masa.Utils.Development.Dapr/README.zh-CN.md
@@ -1,0 +1,79 @@
+中 | [EN](README.md)
+
+## Masa.Utils.Development.Dapr
+
+Dapr Starter核心库
+
+职责：
+
+为Masa.Utils.Development.Dapr.AspNetCore 提供核心支撑，支持windows、linux、OSX
+
+dapr进程的启动、停止、刷新、dapr守护进程均由此类库提供
+
+### 用法：
+
+1. 安装Masa.Utils.Development.Dapr.AspNetCore
+```C#
+Install-Package Masa.Utils.Development.Dapr.AspNetCore
+```
+
+2. 添加DaprStarter协助管理dapr进程（建议在开发环境使用）
+
+```C#
+builder.Services.AddDaprStarterCore();
+```
+
+3. 根据需要在指定位置注入IDaprProcess, 之后调用Start方法即可启动dapr进程或者交由Masa.Utils.Development.Dapr.AspNetCore管理dapr进程，相关文档可[查看](../Masa.Utils.Development.Dapr.AspNetCore/README.zh-CN.md)
+
+例如：
+
+新建DaprController
+
+``` C# DaprController.cs
+public class DaprController : ControllerBase
+{
+    private readonly IDaprProcess _daprProcess;
+
+    private readonly DaprOptions _options;
+
+    public DaprController(IDaprProcess daprProcess, IOptions<DaprOptions> options)
+    {
+        _daprProcess = daprProcess;
+        _options = options.Value;
+    }
+
+    [HttpGet(Name = "Start")]
+    public string Start()
+    {
+        _daprProcess.Start(_options);
+        return "start success";
+    }
+
+    [HttpGet(Name = "Stop")]
+    public string Stop()
+    {
+        _daprProcess.Stop();
+        return "stop success";
+    }
+}
+```
+
+## 注意
+
+库中有使用到netstat命令，请确保netstat命令是可用的
+
+> Windows系统默认支持netstat命令无需特殊安装
+>
+> Linux与OSX需要自行确认确认电脑是否安装netstat
+
+打开终端输入以下命令确认电脑支持netstat命令：
+
+```
+netstat -h
+```
+
+例：ubuntu：
+
+```
+apt-get install net-tools
+```

--- a/src/Development/Masa.Utils.Development.Dapr/README.zh-CN.md
+++ b/src/Development/Masa.Utils.Development.Dapr/README.zh-CN.md
@@ -60,7 +60,7 @@ public class DaprController : ControllerBase
 
 ## 注意
 
-库中有使用到netstat命令，请确保netstat命令是可用的
+1. 库中有使用到netstat命令，请确保netstat命令是可用的
 
 > Windows系统默认支持netstat命令无需特殊安装
 >
@@ -77,3 +77,19 @@ netstat -h
 ```
 apt-get install net-tools
 ```
+
+2. AppId、AppIdSuffix强烈建议不要输入含.的字符串，否则会导致dapr调用出现问题，推荐使用-
+   1. Dapr AppID遵循FQDN格式，其中包括目标命名空间
+   2. FQDN是通过符号.来拼接域名的
+
+### 规则
+
+dapr AppId命名规则默认：
+
+AppId + "-" +  AppIdSuffix
+
+AppId默认：Appid.Replace(".","-")
+
+AppIdSuffix默认：网卡地址
+
+当AppIdSuffix为空时，dapr的appid等于AppId

--- a/src/Development/Masa.Utils.Development.Dapr/ServiceCollectionExtensions.cs
+++ b/src/Development/Masa.Utils.Development.Dapr/ServiceCollectionExtensions.cs
@@ -4,14 +4,10 @@ public static class ServiceCollectionExtensions
 {
     public static IServiceCollection AddDaprStarterCore(this IServiceCollection services, Action<DaprOptions>? action = null)
     {
-        DaprOptions daprOptions = new();
-        action?.Invoke(daprOptions);
-        return services.AddDaprStarterCore(() => daprOptions);
-    }
-
-    public static IServiceCollection AddDaprStarterCore(this IServiceCollection services, Func<DaprOptions> func)
-    {
-        services.AddSingleton(Options.Create(func.Invoke()));
+        if (action != null)
+            services.Configure(action);
+        else
+            services.Configure<DaprOptions>(_ => { });
         return services.AddDaprStarterCore();
     }
 
@@ -24,9 +20,7 @@ public static class ServiceCollectionExtensions
     private static IServiceCollection AddDaprStarterCore(this IServiceCollection services)
     {
         if (services.Any(service => service.ImplementationType == typeof(DaprService)))
-        {
             return services;
-        }
         services.AddSingleton<DaprService>();
 
         services.TryAddSingleton(typeof(IDaprProcess), typeof(DaprProcess));


### PR DESCRIPTION
1. fix PlacementHostAddress is invalid, unable to associate Placement
2. Support setting Sentry
3. fix the problem of invalid custom dapr configuration
4. fix http port, grpc port assignment disorder problem (affects dapr call)
5. dapr starter supports turning off heartbeat checking
6. CallerBase changes Name to an abstract attribute, prompting the user that Name is a required item, so as to avoid errors when using and not knowing the assigned object